### PR TITLE
Relax mutex earlier in FT_Invocation_Endpoint_Selector::select_*()

### DIFF
--- a/TAO/orbsvcs/orbsvcs/FaultTolerance/FT_Invocation_Endpoint_Selectors.cpp
+++ b/TAO/orbsvcs/orbsvcs/FaultTolerance/FT_Invocation_Endpoint_Selectors.cpp
@@ -49,25 +49,32 @@ TAO_FT_Invocation_Endpoint_Selector::select_primary (
     TAO::Profile_Transport_Resolver *r,
     ACE_Time_Value *max_wait_time)
 {
+  TAO_MProfile *prof_list;
+  TAO_MProfile prof_list_aux;
+
+  // Retrieve the list of profiles to be used.
   // Set lock, as forward_profiles might be deleted concurrently.
-  ACE_MT (ACE_GUARD_RETURN (TAO_SYNCH_MUTEX,
-                            guard,
-                            const_cast <TAO_SYNCH_MUTEX &> (r->stub ()->profile_lock ()),
-                            false));
+  {
+    ACE_MT (ACE_GUARD_RETURN (TAO_SYNCH_MUTEX,
+                              guard,
+                              const_cast <TAO_SYNCH_MUTEX &> (r->stub ()->profile_lock ()),
+                              false));
 
-  // Grab the forwarded list
-  TAO_MProfile *prof_list =
-    const_cast<TAO_MProfile *> (r->stub ()->forward_profiles ());
+    // Grab the forwarded list
+    TAO_MProfile *forward_prof_list =
+      const_cast<TAO_MProfile *> (r->stub ()->forward_profiles ());
 
-  TAO_MProfile &basep = r->stub ()->base_profiles ();
-
-  if (prof_list ==0)
-    {
-      prof_list = &basep;
-      // No need to hold stub lock any more. We needed it only to use
-      // forward_profiles.
-      guard.release ();
-    }
+    if (forward_prof_list == 0)
+      {
+        TAO_MProfile &basep = r->stub ()->base_profiles ();
+        prof_list = &basep;
+      }
+    else
+      {
+        prof_list_aux.set(*forward_prof_list);
+        prof_list = &prof_list_aux;
+      }
+  }
 
   if (prof_list == 0)
     return false;
@@ -107,26 +114,32 @@ TAO_FT_Invocation_Endpoint_Selector::select_secondary (
     TAO::Profile_Transport_Resolver *r,
     ACE_Time_Value *max_wait_time)
 {
+  TAO_MProfile *prof_list;
+  TAO_MProfile prof_list_aux;
+
+  // Retrieve the list of profiles to be used.
   // Set lock, as forward_profiles might be deleted concurrently.
-  ACE_MT (ACE_GUARD_RETURN (TAO_SYNCH_MUTEX,
-                            guard,
-                            const_cast <TAO_SYNCH_MUTEX &> (r->stub ()->profile_lock ()),
-                            false));
+  {
+    ACE_MT (ACE_GUARD_RETURN (TAO_SYNCH_MUTEX,
+                              guard,
+                              const_cast <TAO_SYNCH_MUTEX &> (r->stub ()->profile_lock ()),
+                              false));
 
-  // Grab the forwarded list
-  TAO_MProfile *prof_list =
-    const_cast<TAO_MProfile *> (r->stub ()->forward_profiles ());
+    // Grab the forwarded list
+    TAO_MProfile *forward_prof_list =
+      const_cast<TAO_MProfile *> (r->stub ()->forward_profiles ());
 
-  TAO_MProfile &basep =
-    r->stub ()->base_profiles ();
-
-  if (prof_list ==0)
-    {
-      prof_list = &basep;
-      // No need to hold stub lock any more. We needed it only to use
-      // forward_profiles.
-      guard.release ();
-    }
+    if (forward_prof_list == 0)
+      {
+        TAO_MProfile &basep = r->stub ()->base_profiles ();
+        prof_list = &basep;
+      }
+    else
+      {
+        prof_list_aux.set(*forward_prof_list);
+        prof_list = &prof_list_aux;
+      }
+  }
 
   if (prof_list == 0)
     return false;


### PR DESCRIPTION
***********\* OVERVIEW ************
When a LocationForward occurred and that TAO is retrieving a profile to which it can get connected, then all new outgoing requests are blocked by a mutex in TAO_FT_Invocation_Endpoint_Selector::select_primary or in TAO_FT_Invocation_Endpoint_Selector::select_secondary, as long as the request in progress has not found any profile.
It looks like that each request, once it got the mutex, will try to connect to each profile of the IOGR at the moment it arrived, and will not necessarily use the IOGR updated by the first request. If some profiles are unreachable, then the attempts of connection can be long, and consequently all pending requests will be delayed. 
If one configure a Relative RoundTrip Timeout, he will possibly get TIMEOUT to these requests while there would be enough time to get a reply from the new primary.

***********\* ISSUE ************
I have a use case with a FT client sending many requests to a FT replicated server, and the FT primary server is unplugged from the network. 
We expect all requests to be forwarded to the new primary once the switch is over, but many requests get TIMEOUT instead.

For a disconnection of 10.100.14.96 at 16:50:01Z and a RTTT=20s (/var/log/messages-20160214:Feb 12 16:50:01 systint85 kernel: bnx2 0000:03:00.0: eth0: NIC Copper Link is Down), the failure of TCP connection is detected after 6s (as expected, thanks to the TCP Keep Alive we have configured):
#16:50:08.107683

TAO (20595|140665202775808) - Synch_Twoway_Invocation::wait_for_reply, timeout after recv is <13602> status <-1>
TAO (20595|140665202775808) - Synch_Twoway_Invocation::wait_for_reply, recovering after an error
...
#16:50:23.041159

TAO_FT (20595|140665202775808) - Got a primary component

And then some attempts of reconnection fail after 3s, accordingly to the TCP parameter tcp_retries2=3.
#16:50:23.042602

TAO (20595|140665202775808) - IIOP_Connector::begin_connection, to 10.100.14.96:11063 which should block
...
#16:50:26.481488

TAO (20595|140665202775808) - Synch_Twoway_Invocation::wait_for_reply, timeout after recv is <0> status <-1>
TAO (20595|140665202775808) - Synch_Twoway_Invocation::wait_for_reply, recovering after an error

A very long time (15s here) is spent between the failure and the first attempt of reconnection, which looks to be only explained by the time needed to gain the mutex in FTSelector.
All requests will pay the cost of 3s when attempting the unreachable profile, and last ones will finish with a TIMEOUT.

***********\* FIX ************
Making a copy of profiles and release immediately the Mutex enables to all requests to be processed at the same time, they will all try to find the right profile concurrently.
That fix has been validated on the old TAO-V161, however the relative code looks to have been very stable since then and it may work the same in latest releases.
